### PR TITLE
disable clear convo button when there are no messages

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -111,7 +111,7 @@ const Chat = () => {
               education, etc, but avoid sharing personal information.
             </Typography>
             <Button
-        
+
               sx={{
                 width: "200px",
                 my: "auto",
@@ -123,7 +123,10 @@ const Chat = () => {
                 ":hover": {
                   bgcolor: red.A400,
                 },
-              }} onClick={handleDeleteChats}
+                mb: 5,
+              }} 
+              onClick={handleDeleteChats}
+              disabled={chatMessages.length === 0}
             >
               Clear Conversation
             </Button>


### PR DESCRIPTION
added a disabled property to the clear conversation button. when there are no chatMessages, then disable button. 
added mb to the button to give some space to the distance of the bottom of the button from the bottom of the box